### PR TITLE
Updates to Shift & Basic Boundary Condition Handling

### DIFF
--- a/meshTesting.cpp
+++ b/meshTesting.cpp
@@ -134,7 +134,8 @@ if(programBranch ==0)
                 testPoint.x = point3(randomLocationOnRandomFace.second[0],randomLocationOnRandomFace.second[1],randomLocationOnRandomFace.second[2]);
                 testPoint.faceIndex = fdTest;
                 p2.start();
-                meshSpace->displaceParticle(testPoint, displacementVector);
+		vector<vector3> emptyVectors;
+                meshSpace->transportParticleAndVectors(testPoint, displacementVector, emptyVectors);
                 p2.end();
                 pos2.push_back(testPoint);
                 targetFL.first=(faceIndex) testPoint.faceIndex;
@@ -234,7 +235,8 @@ if(programBranch ==0)
 
 
     std::cout << source.faceIndex << ", " << source.x << std::endl;
-    meshSpace->displaceParticle(source, displacement);
+    vector<vector3> emptyVectors;
+    meshSpace->transportParticleAndVectors(source, displacement, emptyVectors);
     std::cout << source.faceIndex << ", " << source.x << std::endl;
     };
 /*

--- a/src/models/baseSpace.h
+++ b/src/models/baseSpace.h
@@ -24,13 +24,10 @@ class baseSpace
     {
     public:
         virtual ~baseSpace() = default;
-        //!displace the position of a particle
-        virtual void displaceParticle(meshPosition &pos, vector3 &displacementVector) = 0;
-
-        //!move a particle and, if necessary, update the associated velocity vector
-        virtual void transportParticleAndVelocity(meshPosition &pos, vector3 &v, vector3 &displacementVector) = 0;
-
-        //!Given a source particle and a vector of target points, determine the geodesic distance and store the start and end path tangents along the paths. The tangents are stored as NORMALIZED vectors
+        //!all-in-one to move a particle and any accompanying vectors
+        virtual void transportParticleAndVectors(meshPosition &pos, vector3 &displacementVector, vector<vector3> &transportVectors) = 0;
+	
+	//!Given a source particle and a vector of target points, determine the geodesic distance and store the start and end path tangents along the paths. The tangents are stored as NORMALIZED vectors
         virtual void distance(meshPosition &p1, std::vector<meshPosition> &p2, std::vector<double> &distances, std::vector<vector3> &startPathTangent, std::vector<vector3> &endPathTangent, double distanceThreshold) = 0;
 
         //given a vector of meshPositions, extract some double3 information

--- a/src/models/baseSpace.h
+++ b/src/models/baseSpace.h
@@ -24,6 +24,9 @@ class baseSpace
     {
     public:
         virtual ~baseSpace() = default;
+        //!displace the position of a particle
+        virtual void displaceParticle(meshPosition &pos, vector3 &displacementVector) = 0;
+
         //!all-in-one to move a particle and any accompanying vectors
         virtual void transportParticleAndVectors(meshPosition &pos, vector3 &displacementVector, vector<vector3> &transportVectors) = 0;
 	

--- a/src/models/euclideanSpace.cpp
+++ b/src/models/euclideanSpace.cpp
@@ -7,7 +7,7 @@ void euclideanSpace::displaceParticle(meshPosition &pos, vector3 &displacementVe
 
 void euclideanSpace::transportParticleAndVectors(meshPosition &pos, vector3 &displacementVector, vector<vector3> &transportVectors)
     {
-    pos.x += displacementVector;
+    displaceParticle(pos,displacementVector);
     } 
  
 void euclideanSpace::meshPositionToEuclideanLocation(std::vector<meshPosition> &p1, std::vector<meshPosition> &result)

--- a/src/models/euclideanSpace.cpp
+++ b/src/models/euclideanSpace.cpp
@@ -5,10 +5,10 @@ void euclideanSpace::displaceParticle(meshPosition &pos, vector3 &displacementVe
     pos.x += displacementVector;
     };
 
-void euclideanSpace::transportParticleAndVelocity(meshPosition &pos, vector3 &v, vector3 &displacementVector)
+void euclideanSpace::transportParticleAndVectors(meshPosition &pos, vector3 &displacementVector, vector<vector3> &transportVectors)
     {
-    displaceParticle(pos,displacementVector);
-    }
+    pos.x += displacementVector;
+    } 
  
 void euclideanSpace::meshPositionToEuclideanLocation(std::vector<meshPosition> &p1, std::vector<meshPosition> &result)
     {

--- a/src/models/euclideanSpace.h
+++ b/src/models/euclideanSpace.h
@@ -15,7 +15,7 @@ class euclideanSpace : public baseSpace
         //!Simple vector addition of particle displacements
         virtual void displaceParticle(meshPosition &pos, vector3 &displacementVector);
         //!this function is useful in triangulatedMeshSpaces, but meaningless here where transport is trivial
-	virtual void transportParticleAndVectors(meshPosition &pos, vector3 &displacementVector, vector<vector3> &transportVectors); 
+        virtual void transportParticleAndVectors(meshPosition &pos, vector3 &displacementVector, vector<vector3> &transportVectors); 
 	
 
         //!Simple vector subtraction for particle separation vectors

--- a/src/models/euclideanSpace.h
+++ b/src/models/euclideanSpace.h
@@ -14,8 +14,9 @@ class euclideanSpace : public baseSpace
     public:
         //!Simple vector addition of particle displacements
         virtual void displaceParticle(meshPosition &pos, vector3 &displacementVector);
-        //! in euclideanSpace, velocity vectors are unchanged by particle shifts...this just calls displace particle
-        virtual void transportParticleAndVelocity(meshPosition &pos, vector3 &v, vector3 &displacementVector);
+        //!this function is useful in triangulatedMeshSpaces, but meaningless here where transport is trivial
+	virtual void transportParticleAndVectors(meshPosition &pos, vector3 &displacementVector, vector<vector3> &transportVectors); 
+	
 
         //!Simple vector subtraction for particle separation vectors
         virtual void distance(meshPosition &p1, std::vector<meshPosition> &p2, std::vector<double> &distances, std::vector<vector3> &startPathTangent, std::vector<vector3> &endPathTangent, double distanceThreshold = VERYLARGEDOUBLE);

--- a/src/models/simpleModel.cpp
+++ b/src/models/simpleModel.cpp
@@ -42,14 +42,24 @@ void simpleModel::fillEuclideanLocations()
 
 void simpleModel::moveParticles(vector<vector3> &disp)
     {
-    if(!particleShiftsRequireVelocityTransport)
-        {
         for(int ii = 0; ii < N; ++ii)
-            space->displaceParticle(positions[ii],disp[ii]);
-        }
-    else
-        for(int ii = 0; ii < N; ++ii)
-            space->transportParticleAndVelocity(positions[ii],velocities[ii],disp[ii]);
+	    {
+	    vector<vector3> transports;
+	    if(particleShiftsRequireForceTransport) transports.push_back(forces[ii]);
+            if(particleShiftsRequireVelocityTransport) transports.push_back(velocities[ii]); 
+            space->transportParticleAndVectors(positions[ii],disp[ii], transports);
+	    int transportCounter = 0;
+	    if (particleShiftsRequireForceTransport) 
+	        {
+		forces[ii] = transports[transportCounter];
+		transportCounter++;
+		}
+	    if(particleShiftsRequireVelocityTransport)
+		{
+                velocities[ii] = transports[transportCounter];
+		transportCounter++;
+		}
+	    }
     };
 
 void simpleModel::findNeighbors(double maximumInteractionRange)

--- a/src/models/simpleModel.cpp
+++ b/src/models/simpleModel.cpp
@@ -40,25 +40,32 @@ void simpleModel::fillEuclideanLocations()
     space->meshPositionToEuclideanLocation(positions,euclideanLocations);
     }
 
+/*!
+ moveParticles currently loops through possible parallel transport flags and fills 
+ a vector of vector3s... if we write more potential quantities to be transported in this way,
+ we should update this structure to something a bit cleaner.
+ */
 void simpleModel::moveParticles(vector<vector3> &disp)
     {
-        for(int ii = 0; ii < N; ++ii)
+    for(int ii = 0; ii < N; ++ii)
 	    {
 	    vector<vector3> transports;
-	    if(particleShiftsRequireForceTransport) transports.push_back(forces[ii]);
-            if(particleShiftsRequireVelocityTransport) transports.push_back(velocities[ii]); 
-            space->transportParticleAndVectors(positions[ii],disp[ii], transports);
+	    if(particleShiftsRequireForceTransport)
+            transports.push_back(forces[ii]);
+        if(particleShiftsRequireVelocityTransport)
+            transports.push_back(velocities[ii]); 
+        space->transportParticleAndVectors(positions[ii],disp[ii], transports);
 	    int transportCounter = 0;
 	    if (particleShiftsRequireForceTransport) 
 	        {
-		forces[ii] = transports[transportCounter];
-		transportCounter++;
-		}
+            forces[ii] = transports[transportCounter];
+            transportCounter++;
+            }
 	    if(particleShiftsRequireVelocityTransport)
-		{
-                velocities[ii] = transports[transportCounter];
-		transportCounter++;
-		}
+            {
+            velocities[ii] = transports[transportCounter];
+            transportCounter++;
+            }
 	    }
     };
 

--- a/src/models/simpleModel.h
+++ b/src/models/simpleModel.h
@@ -98,6 +98,8 @@ class simpleModel
         void setVerbose(bool v){verbose = v;};
         //!some updaters require parallel transport of velocity vectors
         bool particleShiftsRequireVelocityTransport = false;
+        //!some updaters require parallel transport of force vectors
+	bool particleShiftsRequireForceTransport = false; 
 
         //!tolerance used for barycentricCoordinate clamping    :with
         double clampTolerance = 0.00000000000001;//10^-14 as a current threshold for numerical tolerance. 

--- a/src/models/triangulatedMeshSpace.cpp
+++ b/src/models/triangulatedMeshSpace.cpp
@@ -405,7 +405,8 @@ void triangulatedMeshSpace::projectVectorsIfOverBoundary(vector<vector3> &vector
         vector3 v = vectors[i];
         double vAndPerpDot = v*orthogonal;
         bool vAlongPerp = (vAndPerpDot > 0);
-        if ((pointsOut && vAlongPerp) || (!pointsOut && !vAlongPerp)) projectOrthogonalTo(v,orthogonal);
+        if ((pointsOut && vAlongPerp) || (!pointsOut && !vAlongPerp)) 
+            projectVectorOrthongonalToDirection(v,orthogonal);
         vectors[i] = v;
         }
     }
@@ -585,7 +586,7 @@ void triangulatedMeshSpace::transportParticleAndVectors(meshPosition &pos, vecto
                 //now update the displacement vector to be along the boundary if tangential bcs
 		if (useTangentialBCs) 
 		    {
-		    projectOn(displacementVector,boundaryHeading);
+		    projectVectorOntoDirection(displacementVector,boundaryHeading);
 		    target = edgeIntersectionPoint+displacementVector;	
 		    }
 		else 

--- a/src/models/triangulatedMeshSpace.cpp
+++ b/src/models/triangulatedMeshSpace.cpp
@@ -435,6 +435,12 @@ void triangulatedMeshSpace::checkBaryNan(pmpBarycentricCoordinates bcoords, stri
          }
     }
 
+void triangulatedMeshSpace::displaceParticle(meshPosition &pos, vector3 &displacementVector)
+    {
+    vector<vector3> emptyTransportQuantities;
+    transportParticleAndVectors(pos,displacementVector,emptyTransportQuantities);
+    };
+
 /*
 Core displacement routine. Takes a degree of freedom and a direction + distance to move in, and moves 
 it around the mesh, always remaining in the tangent plane of a mesh face. Any vectors passed in as transportVectors 

--- a/src/models/triangulatedMeshSpace.cpp
+++ b/src/models/triangulatedMeshSpace.cpp
@@ -484,7 +484,7 @@ void triangulatedMeshSpace::transportParticleAndVectors(meshPosition &pos, vecto
         std::vector<int> uninvolvedVertex;
         std::vector<vertexIndex> involvedVertex;
 
-        bool ifIntersection = findTriangleEdgeIntersectionInformation(sourceBarycentricLocation,targetBarycentricLocation,intersectionPoint, vertexList,lastUsedHalfedge,surface, involvedVertex,uninvolvedVertex);
+        findTriangleEdgeIntersectionInformation(sourceBarycentricLocation,targetBarycentricLocation,intersectionPoint, vertexList,lastUsedHalfedge,surface, involvedVertex,uninvolvedVertex);
         /* after above, the following are written to:
          * involvedVertex (vertex index)
          * uninvolvedVertex (integer)

--- a/src/models/triangulatedMeshSpace.cpp
+++ b/src/models/triangulatedMeshSpace.cpp
@@ -460,11 +460,11 @@ void triangulatedMeshSpace::transportParticleAndVectors(meshPosition &pos, vecto
         iter+=1;
         //get the current barycentric coordinates of the target, clamping to the edge if they're very close 
         targetBarycentricLocation = PMP::barycentric_coordinates(vertexPositions[0],vertexPositions[1],vertexPositions[2],target);
-        clampAndUpdatePosition(targetBarycentricLocation, target, currentSourceFace);  
+        clampAndUpdatePosition(targetBarycentricLocation, target, currentSourceFace,surface);
         //while we don't want to eliminate negatives from the target, the source point should strictly lie within the source face, 
         //so we can use the stricter belowZeroClamp. This does not exclude the use of controls during the other parts of the loop to 
         //ensure that the source point is actually in or nearly in the face
-        clampAndUpdatePosition(sourceBarycentricLocation, sourcePoint, currentSourceFace, useBelowZero);
+        clampAndUpdatePosition(sourceBarycentricLocation, sourcePoint, currentSourceFace, surface,useBelowZero);
         displacementVector = vector3(sourcePoint,target);
 
         checkBaryNan(targetBarycentricLocation, "start of step check", iter); 

--- a/src/models/triangulatedMeshSpace.cpp
+++ b/src/models/triangulatedMeshSpace.cpp
@@ -279,9 +279,10 @@ std::pair<faceIndex,vector3> triangulatedMeshSpace::throughVertex(vertexIndex &i
         if (started && atStartPoint) unfinished=false; //finishing counting, or
         else //start counting + continue counting 
        	    {
-            if (atStartPoint) started=true; //this lets us know we can start counting, second condition will be filled until done
+            if (atStartPoint) 
+                started=true; //this lets us know we can start counting, second condition will be filled until done
             if (started)
-	        {
+                {
                 neighborIndicesCopy.push_back(currentVert);
                 neighborVertices.push_back(surface.point(currentVert));
                 };
@@ -292,10 +293,11 @@ std::pair<faceIndex,vector3> triangulatedMeshSpace::throughVertex(vertexIndex &i
     int numNeighbors = neighborVertices.size();
     edgeVectors.reserve(numNeighbors);
 
-    for (int i = 0; i < numNeighbors; i++) {
+    for (int i = 0; i < numNeighbors; i++)
+        {
         point3 v = neighborVertices[i];
         edgeVectors.push_back(normalize(vector3(vi_r3, v)));
-    }
+        }
 
     double totalAngle = 0;
     for (int i = 0; i < numNeighbors; i++)
@@ -304,7 +306,7 @@ std::pair<faceIndex,vector3> triangulatedMeshSpace::throughVertex(vertexIndex &i
         vector3 v2 = edgeVectors[(i+1)%numNeighbors];
         totalAngle += angleBetween(v1,v2);
         }
-     //now -- pick the vector in a target face that corresponds to having
+    //now -- pick the vector in a target face that corresponds to having
     //exactly half of the total angle of the vertex between it and the
     //vector from the original source to the vertex itself.
     double angleToTravel = totalAngle/2.0;
@@ -320,7 +322,7 @@ std::pair<faceIndex,vector3> triangulatedMeshSpace::throughVertex(vertexIndex &i
         angleTraveled += angleBetween(e1, e2);
         counter ++; // counter will always finish on the e2 index
         if (counter >= numNeighbors) 
-	    {
+            {
             printf("did not find an angular halfway when picking heading from a vertex, debug!");
             break;
             }
@@ -345,11 +347,10 @@ std::pair<faceIndex,vector3> triangulatedMeshSpace::throughVertex(vertexIndex &i
         {
         cand = *fbegin++; //the next face to add is the face pointed to by the next
                         //iteration of the iterator
-        if (cand == sourceFace) continue; //don't need to consider the face we're coming from
+        if (cand == sourceFace) 
+            continue; //don't need to consider the face we're coming from
         else 
-	    {
             candidateFaces.push_back(cand);
-            }
         } while(fbegin != fdone);
 
     //null result is target face being the same as the source face
@@ -362,9 +363,9 @@ std::pair<faceIndex,vector3> triangulatedMeshSpace::throughVertex(vertexIndex &i
     for (faceIndex face: candidateFaces) 
         {
         //below is glorified check to see if all the vertices of the face are the 
-	//same as the vertices of the two edges we need to be included
+        //same as the vertices of the two edges we need to be included
         std::vector<vertexIndex> currentFaceVs(3); 
-	getVertexIndicesFromFace(surface, face, currentFaceVs);
+        getVertexIndicesFromFace(surface, face, currentFaceVs);
         std::set<vertexIndex> currentVsSet;
         currentVsSet.insert(currentFaceVs[0]);
         currentVsSet.insert(currentFaceVs[1]);
@@ -386,10 +387,7 @@ std::pair<faceIndex,vector3> triangulatedMeshSpace::throughVertex(vertexIndex &i
             }
         }
     if (sourceFace == targetFace) 
-        {
-	printf("throughvertex didn't find a face, debug!"); 
-	throw std::exception();
-        }
+        ERRORERROR("throughvertex didn't find a face");
     return std::make_pair(targetFace,prospHeading); 
     }  
 
@@ -462,12 +460,12 @@ void triangulatedMeshSpace::transportParticleAndVectors(meshPosition &pos, vecto
         iter+=1;
         //get the current barycentric coordinates of the target, clamping to the edge if they're very close 
         targetBarycentricLocation = PMP::barycentric_coordinates(vertexPositions[0],vertexPositions[1],vertexPositions[2],target);
-	clampAndUpdatePosition(targetBarycentricLocation, target, currentSourceFace);  
-	//while we don't want to eliminate negatives from the target, the source point should strictly lie within the source face, 
-	//so we can use the stricter belowZeroClamp. This does not exclude the use of controls during the other parts of the loop to 
-	//ensure that the source point is actually in or nearly in the face
+        clampAndUpdatePosition(targetBarycentricLocation, target, currentSourceFace);  
+        //while we don't want to eliminate negatives from the target, the source point should strictly lie within the source face, 
+        //so we can use the stricter belowZeroClamp. This does not exclude the use of controls during the other parts of the loop to 
+        //ensure that the source point is actually in or nearly in the face
         clampAndUpdatePosition(sourceBarycentricLocation, sourcePoint, currentSourceFace, useBelowZero);
-	displacementVector = vector3(sourcePoint,target);
+        displacementVector = vector3(sourcePoint,target);
 
         checkBaryNan(targetBarycentricLocation, "start of step check", iter); 
         //if the targetBarycentricLocation is in the face, we have found our destination, so check this before implementing all of the intersection locating and vector rotating logic
@@ -475,7 +473,7 @@ void triangulatedMeshSpace::transportParticleAndVectors(meshPosition &pos, vecto
         for (int cc = 0; cc <3; ++cc)
             if(targetBarycentricLocation[cc] < 0)
                 intersectionWithEdge = true; 
-	if(!intersectionWithEdge)
+        if(!intersectionWithEdge)
             {
             continueShifting = false;
             continue;
@@ -485,255 +483,257 @@ void triangulatedMeshSpace::transportParticleAndVectors(meshPosition &pos, vecto
         pmpBarycentricCoordinates intersectionPoint;
         std::vector<int> uninvolvedVertex;
         std::vector<vertexIndex> involvedVertex;
-        
-	bool ifIntersection = findTriangleEdgeIntersectionInformation(sourceBarycentricLocation,targetBarycentricLocation,intersectionPoint, vertexList,lastUsedHalfedge,surface, involvedVertex,uninvolvedVertex);
+
+        bool ifIntersection = findTriangleEdgeIntersectionInformation(sourceBarycentricLocation,targetBarycentricLocation,intersectionPoint, vertexList,lastUsedHalfedge,surface, involvedVertex,uninvolvedVertex);
         /* after above, the following are written to:
          * involvedVertex (vertex index)
          * uninvolvedVertex (integer)
          * intersection point (barycentric coords)
          */
-	vector3 toIntersection;
-	//below are just placeholder values which are only defined if we go through a vertex
+        vector3 toIntersection;
+        //below are just placeholder values which are only defined if we go through a vertex
         faceIndex provisionalTargetFace = currentSourceFace;
         vector3 newHeading = vector3(0,0,0);
         point3 edgeIntersectionPoint;
-        
-	if(uninvolvedVertex.size() == 2)
+
+        if(uninvolvedVertex.size() == 2)
             {
-	    cout << "Vertex intersection! " << endl;
+            /*cout << "Vertex intersection! " << endl;*/
             if (surface.is_border(vertexIndex(involvedVertex[0])))
                 {
-	        cout << "Boundary vertex." << endl;
+                /*cout << "Boundary vertex." << endl;*/
                 //ensure intersection point is in current face -- over the boundary does not exist.
                 belowZeroClamp(intersectionPoint);                 
-		edgeIntersectionPoint = globalSMSP->point(currentSourceFace,intersectionPoint);
-		//walk to the location of the intersection by moving the source point. 
-		sourceBarycentricLocation = intersectionPoint;
-		sourcePoint = edgeIntersectionPoint;
-		    
-		std::vector<faceIndex> faceIndices;
-		std::vector<std::pair<vertexIndex,faceIndex>> neighborsAndFaces; 
-		faceIndices.reserve(8);
+                edgeIntersectionPoint = globalSMSP->point(currentSourceFace,intersectionPoint);
+                //walk to the location of the intersection by moving the source point. 
+                sourceBarycentricLocation = intersectionPoint;
+                sourcePoint = edgeIntersectionPoint;
+
+                std::vector<faceIndex> faceIndices;
+                std::vector<std::pair<vertexIndex,faceIndex>> neighborsAndFaces; 
+                faceIndices.reserve(8);
                 neighborsAndFaces.reserve(8); 
-                
-	        faceIndex cand;	
-		faceCirculator fbegin(surface.halfedge(vertexIndex(involvedVertex[0])), surface), fdone(fbegin);
-		do 
-		    {
-		    cand = *fbegin++; 
-		    if (cand == currentSourceFace) continue;
-		    else faceIndices.push_back(cand); 
-		    } while (fbegin != fdone);       
-	       
-		vertexCirculator vbegin(surface.halfedge(vertexIndex(involvedVertex[0])),surface), done(vbegin);
+
+                faceIndex cand;	
+                faceCirculator fbegin(surface.halfedge(vertexIndex(involvedVertex[0])), surface), fdone(fbegin);
+                do 
+                    {
+                    cand = *fbegin++; 
+                    if (cand == currentSourceFace) 
+                        continue;
+                    else 
+                        faceIndices.push_back(cand); 
+                    } while (fbegin != fdone);       
+
+                vertexCirculator vbegin(surface.halfedge(vertexIndex(involvedVertex[0])),surface), done(vbegin);
                 do 
                     {
                     for (faceIndex f: faceIndices) 
-	                { 
-		        if (surface.face(surface.halfedge(*vbegin++)) == f) neighborsAndFaces.push_back(make_pair(*vbegin++, f)); 
-		        }	
-		    } while(vbegin != done);	
-		
-		//below serves the rule that the next heading will be along the edge that maximally 
-		//overlaps with the present heading. 
-		double maxOverlap = -1; //dummy value, should always be overwritten
-		double currentOverlap = 0; 
-		vector3 boundaryHeading = vector3(0,0,0); 
-		faceIndex nextFace = currentSourceFace;
+                        { 
+                        if (surface.face(surface.halfedge(*vbegin++)) == f)
+                            neighborsAndFaces.push_back(make_pair(*vbegin++, f)); 
+                        }	
+                    } while(vbegin != done);	
+
+                //below serves the rule that the next heading will be along the edge that maximally 
+                //overlaps with the present heading. 
+                double maxOverlap = -1; //dummy value, should always be overwritten
+                double currentOverlap = 0; 
+                vector3 boundaryHeading = vector3(0,0,0); 
+                faceIndex nextFace = currentSourceFace;
                 vertexIndex boundaryVertex = involvedVertex[0]; 
 
-		for (auto vi: neighborsAndFaces) 
-	            {
-		    vector3 outwardVector(surface.point(involvedVertex[0]),surface.point(vi.first));
-		    outwardVector = normalize(outwardVector);
+                for (auto vi: neighborsAndFaces) 
+                    {
+                    vector3 outwardVector(surface.point(involvedVertex[0]),surface.point(vi.first));
+                    outwardVector = normalize(outwardVector);
                     currentOverlap = outwardVector*normalize(displacementVector); 
-		    if (currentOverlap > maxOverlap) 
-		        {
-			boundaryHeading = outwardVector; 
-			maxOverlap = currentOverlap;
-			nextFace = vi.second;
-			boundaryVertex = vi.first;
-			}
+                    if (currentOverlap > maxOverlap) 
+                        {
+                        boundaryHeading = outwardVector; 
+                        maxOverlap = currentOverlap;
+                        nextFace = vi.second;
+                        boundaryVertex = vi.first;
+                        }
                     }
 
-		if (nextFace == currentSourceFace) ERRORERROR("New face not found for boundary vertex crossing.");
-                if (boundaryVertex == involvedVertex[0]) ERRORERROR("vertex not updated in throughvertex boundary crossing"); 
-	        	
+                if (nextFace == currentSourceFace)
+                    ERRORERROR("New face not found for boundary vertex crossing.");
+                if (boundaryVertex == involvedVertex[0]) 
+                    ERRORERROR("vertex not updated in throughvertex boundary crossing"); 
+
                 //now update the displacement vector to be along the boundary if tangential bcs
-		if (useTangentialBCs) 
-		    {
-		    projectVectorOntoDirection(displacementVector,boundaryHeading);
-		    target = edgeIntersectionPoint+displacementVector;	
-		    }
-		else 
-		    {	
+                if (useTangentialBCs) 
+                    {
+                    projectVectorOntoDirection(displacementVector,boundaryHeading);
+                    target = edgeIntersectionPoint+displacementVector;	
+                    }
+                else 
+                    {	
                     continueShifting = false;
-		    targetBarycentricLocation = sourceBarycentricLocation;
-		    } 
-		currentSourceFace = nextFace;
+                    targetBarycentricLocation = sourceBarycentricLocation;
+                    } 
+                currentSourceFace = nextFace;
 
-		getVertexPositionsFromFace(surface,currentSourceFace, vertexPositions);
+                getVertexPositionsFromFace(surface,currentSourceFace, vertexPositions);
                 sourceBarycentricLocation = PMP::barycentric_coordinates(vertexPositions[0], vertexPositions[1], vertexPositions[2], sourcePoint);	
-	        currentSourceNormal = PMP::compute_face_normal(currentSourceFace,surface);
+                currentSourceNormal = PMP::compute_face_normal(currentSourceFace,surface);
 
-		//now project vectors iff they are pointing over the new boundary 		
+                //now project vectors iff they are pointing over the new boundary 		
                 vector3 orthogonalToEdge = normalize(CGAL::cross_product(currentSourceNormal, boundaryHeading));
-	        
-		vector<vertexIndex> sourceVertexIndices;
-		sourceVertexIndices.push_back(vertexIndex(0));
-		sourceVertexIndices.push_back(vertexIndex(0));
-		sourceVertexIndices.push_back(vertexIndex(0));
-		getVertexIndicesFromFace(surface,currentSourceFace,sourceVertexIndices); 
 
-		point3 insideVertex(0,0,0);
-		for (int i = 0; i < 3; i ++) 
-		    {
-	            vertexIndex sourceV = sourceVertexIndices[i];
-		    if ((sourceV == involvedVertex[0]) || (sourceV == boundaryVertex)) continue;
-		    insideVertex = surface.point(sourceV);  
-		    }
-		
-		vector3 inwardVector(surface.point(involvedVertex[0]), insideVertex); 
-	        
-		projectVectorsIfOverBoundary(transportVectors, orthogonalToEdge, inwardVector);	
+                vector<vertexIndex> sourceVertexIndices;
+                sourceVertexIndices.push_back(vertexIndex(0));
+                sourceVertexIndices.push_back(vertexIndex(0));
+                sourceVertexIndices.push_back(vertexIndex(0));
+                getVertexIndicesFromFace(surface,currentSourceFace,sourceVertexIndices); 
 
-		lastUsedHalfedge = nullHalfedge;	
-		checkBaryNan(sourceBarycentricLocation, "post vertex routine check", iter); //purely for debugging
+                point3 insideVertex(0,0,0);
+                for (int i = 0; i < 3; i ++) 
+                    {
+                    vertexIndex sourceV = sourceVertexIndices[i];
+                    if ((sourceV == involvedVertex[0]) || (sourceV == boundaryVertex)) 
+                        continue;
+                    insideVertex = surface.point(sourceV);  
+                    }
+
+                vector3 inwardVector(surface.point(involvedVertex[0]), insideVertex); 
+
+                projectVectorsIfOverBoundary(transportVectors, orthogonalToEdge, inwardVector);	
+
+                lastUsedHalfedge = nullHalfedge;	
+                checkBaryNan(sourceBarycentricLocation, "post vertex routine check", iter); //purely for debugging
                 continue; //this statement ensures that this through boundary vertex branch is isolated from the below
-		}
-	    
-	    toIntersection = vector3(sourcePoint, PMP::construct_point(std::make_pair(currentSourceFace,intersectionPoint), surface)); //always assumed to be from source to intersected vertex
+            }
+            //Or, if the vertex is not on the boundary, we get a much simpler routine:
+            toIntersection = vector3(sourcePoint, PMP::construct_point(std::make_pair(currentSourceFace,intersectionPoint), surface)); //always assumed to be from source to intersected vertex
             std::pair<faceIndex, vector3> targetHeading = throughVertex(involvedVertex[0], toIntersection, currentSourceFace);
             provisionalTargetFace = targetHeading.first;
             newHeading = targetHeading.second; //this heading comes out normalized
-	    }
+        }
 
-	else if(uninvolvedVertex.size() != 1)
+        else if(uninvolvedVertex.size() != 1)
             {
-	    //below is extensive debug output in case there is a major error in shift
-	    cout << endl;
-	    cout << "source r3: "; 
-	    printPoint(sourcePoint); 
-	    cout << endl;
-            
-	    cout << "source bary: ";
-	    printBary(sourceBarycentricLocation, true); 
-	    cout << endl;
-	    
-	    cout << "target: "; 
-	    printPoint(target, true); 
-	    cout << endl;
-            
-	    cout << "target barycentric: ";
-	    printBary(targetBarycentricLocation,true);
-	    cout << endl;
-	    
-	    cout << "displacement vector: " << displacementVector[0] << ", " << displacementVector[1] << ", " << displacementVector[2] << endl; 
-	    ERRORERROR("a barycentric coordinate of the target is negative, but neither 1 nor 2 intersections were found. Apparently some debugging is needed!");
+            //below is extensive debug output in case there is a major error in shift
+            cout << endl;
+            cout << "source r3: "; 
+            printPoint(sourcePoint); 
+            cout << endl;
+
+            cout << "source bary: ";
+            printBary(sourceBarycentricLocation, true); 
+            cout << endl;
+
+            cout << "target: "; 
+            printPoint(target, true); 
+            cout << endl;
+
+            cout << "target barycentric: ";
+            printBary(targetBarycentricLocation,true);
+            cout << endl;
+
+            cout << "displacement vector: " << displacementVector[0] << ", " << displacementVector[1] << ", " << displacementVector[2] << endl; 
+            ERRORERROR("a barycentric coordinate of the target is negative, but neither 1 nor 2 intersections were found. Apparently some debugging is needed!");
             }
-	/*
+
+        /*
         The relevant edge/vertex intersection is now identified.
         intersectionPoint contains the barycentric coordinates of the intersection point
         on a current face. Identify the next face from the relevant halfEdge, update current
         move to be from the edge intersection to the original target, and rotate it around
         the edge according to the angle of the face normals.
         */	
-	        
-	//update the source to be the intersection point
+                
+        //update the source to be the intersection point
         vector3 targetNormal;
         halfedgeIndex intersectedEdge;
         edgeIntersectionPoint = globalSMSP->point(currentSourceFace,intersectionPoint);
         sourceBarycentricLocation = intersectionPoint;
-	sourcePoint = edgeIntersectionPoint;
+        sourcePoint = edgeIntersectionPoint;
         
-	if (uninvolvedVertex.size() == 1)
+        if (uninvolvedVertex.size() == 1)
             {
             intersectedEdge = surface.halfedge(involvedVertex[0],involvedVertex[1]);  
-	    if (surface.is_border(edgeIndex(intersectedEdge)))
+            if (surface.is_border(edgeIndex(intersectedEdge)))
                 {
-		//intersection point *must* lie within the source face or risk a NaN at the boundary 
-	        belowZeroClamp(intersectionPoint); 
-	        edgeIntersectionPoint = globalSMSP->point(currentSourceFace,intersectionPoint);
-	        sourceBarycentricLocation = intersectionPoint; //we have now 'walked' to this intersection point, and will update our heading
+                //intersection point *must* lie within the source face or risk a NaN at the boundary 
+                belowZeroClamp(intersectionPoint); 
+                edgeIntersectionPoint = globalSMSP->point(currentSourceFace,intersectionPoint);
+                sourceBarycentricLocation = intersectionPoint; //we have now 'walked' to this intersection point, and will update our heading
                 sourcePoint = edgeIntersectionPoint;
-	        checkBaryNan(sourceBarycentricLocation, "boundary edge check", iter);
+                checkBaryNan(sourceBarycentricLocation, "boundary edge check", iter);
 
                 point3 ev1 = surface.point(involvedVertex[0]);
                 point3 ev2 = surface.point(involvedVertex[1]);
-		if (useTangentialBCs) 
-		    { 
+                if (useTangentialBCs) 
+                    { 
                     //rotate heading to be tangential to the edge in the direction most aligned with its current heading. 
-		    vector3 edgeVectorForward(ev1,ev2); 
-		    vector3 edgeVectorBackward(ev2,ev1); 
-		    edgeVectorForward = normalize(edgeVectorForward);
-	            edgeVectorBackward = normalize(edgeVectorBackward); 
-		    double forwardDot = normalize(displacementVector)*edgeVectorForward;
-		    double backwardDot = normalize(displacementVector)*edgeVectorBackward; 
-		    double displacementLength = vectorMagnitude(displacementVector);
-		   
-		    //check to see if any of our transported vectors were pointing over a boundary along with the displacement & project if so 
-		    vector3 orthogonalToEdge = normalize(CGAL::cross_product(currentSourceNormal, vector3(ev1,ev2)));
+                    vector3 edgeVectorForward(ev1,ev2); 
+                    vector3 edgeVectorBackward(ev2,ev1); 
+                    edgeVectorForward = normalize(edgeVectorForward);
+                    edgeVectorBackward = normalize(edgeVectorBackward); 
+                    double forwardDot = normalize(displacementVector)*edgeVectorForward;
+                    double backwardDot = normalize(displacementVector)*edgeVectorBackward; 
+                    double displacementLength = vectorMagnitude(displacementVector);
+
+                    //check to see if any of our transported vectors were pointing over a boundary along with the displacement & project if so 
+                    vector3 orthogonalToEdge = normalize(CGAL::cross_product(currentSourceNormal, vector3(ev1,ev2)));
                     //if orthogonal is pointing out, then we want to project only if the overlap with the orthogonal vector is positive; 
-		    //if orthogonal is pointing in, then we want to project only if the overlap with the orthogonal vector is negative. 
-		    point3 innerVertex = vertexPositions[uninvolvedVertex[0]];
+                    //if orthogonal is pointing in, then we want to project only if the overlap with the orthogonal vector is negative. 
+                    point3 innerVertex = vertexPositions[uninvolvedVertex[0]];
                     vector3 inwardVector(edgeIntersectionPoint, innerVertex); 
-		    projectVectorsIfOverBoundary(transportVectors, orthogonalToEdge, inwardVector);
-		    
-		    //now we can change the displacement vector.  
-		    if ((forwardDot <= 0) && (backwardDot <= 0))
-		         {
-                         continueShifting = false;
-			 } 
-		    if (forwardDot > backwardDot) 
-		        {
-			displacementVector = forwardDot*displacementLength*edgeVectorForward;
-		        }	
-		    else 
-		        {
-			displacementVector = backwardDot*displacementLength*edgeVectorBackward; 
-			}
-		        target = edgeIntersectionPoint+displacementVector; 
-		    }
-	
+                    projectVectorsIfOverBoundary(transportVectors, orthogonalToEdge, inwardVector);
+
+                    //now we can change the displacement vector.  
+                    if ((forwardDot <= 0) && (backwardDot <= 0))
+                        continueShifting = false;
+                    if (forwardDot > backwardDot) 
+                        displacementVector = forwardDot*displacementLength*edgeVectorForward;
+                    else 
+                        displacementVector = backwardDot*displacementLength*edgeVectorBackward; 
+                    target = edgeIntersectionPoint+displacementVector; 
+                }
                 //if not tangential BCs, particle stops completely if it hits a boundary
-		else
-		    { 
+                else
+                    { 
                     continueShifting = false;
-		    targetBarycentricLocation = sourceBarycentricLocation; //remove the displacement completely and jump to boundary intersect
-		    }
-				
-		//source face stays the same because we can't cross boundary edges
+                    targetBarycentricLocation = sourceBarycentricLocation; //remove the displacement completely and jump to boundary intersect
+                    }
+
+                //source face stays the same because we can't cross boundary edges
                 lastUsedHalfedge = nullHalfedge; //allows future intersections checks to include this boundary edge
-		if (iter == maximumShiftEdgeCrossings) ERRORERROR("At boundary, shift proceeded for too long!"); 
-		continue;
+                if (iter == maximumShiftEdgeCrossings) 
+                    ERRORERROR("At boundary, shift proceeded for too long!"); 
+                continue;
                 }
 
-	    provisionalTargetFace = surface.face(intersectedEdge);
+            provisionalTargetFace = surface.face(intersectedEdge);
             if (provisionalTargetFace == currentSourceFace)
                 provisionalTargetFace = surface.face(surface.opposite(intersectedEdge));
 
             targetNormal = PMP::compute_face_normal(provisionalTargetFace,surface);
             double normalDotProduct = currentSourceNormal*targetNormal;
             double angle = acos(normalDotProduct);
-            if (normalDotProduct >= 1) angle = 0; //clamp for robustness against precision errors for very similar normals
-	    vector3 axisVector = CGAL::cross_product(currentSourceNormal,targetNormal);
+            if (normalDotProduct >= 1) 
+                angle = 0; //clamp for robustness against precision errors for very similar normals
+            vector3 axisVector = CGAL::cross_product(currentSourceNormal,targetNormal);
             axisVector /= vectorMagnitude(axisVector); //this could use normalize if we wanted to
             std::vector<point3> axis = {sourcePoint, sourcePoint+axisVector};
-            
-	    target = rotateAboutAxis(target, axis, angle);
+
+            target = rotateAboutAxis(target, axis, angle);
             displacementVector = vector3(sourcePoint, target); //move gets updated here
-	    
-	    for (int i = 0; i < transportVectors.size(); i++) 
-	        {
-		vector3 vTr = transportVectors[i];
+
+            for (int i = 0; i < transportVectors.size(); i++) 
+                {
+                vector3 vTr = transportVectors[i];
                 point3 vTrTarget = sourcePoint + vTr;
                 vTrTarget = rotateAboutAxis(vTrTarget, axis, angle);
                 transportVectors[i] = vector3(sourcePoint, vTrTarget);
-	        }
+                }
 
-	    //if we've gone through an edge, it can be excluded from future intersection checks
-	    lastUsedHalfedge = intersectedEdge;        
-       	    }
+            //if we've gone through an edge, it can be excluded from future intersection checks
+            lastUsedHalfedge = intersectedEdge;        
+            }
 
         //two conditions are exclusive
         if (uninvolvedVertex.size() == 2)
@@ -742,41 +742,41 @@ void triangulatedMeshSpace::transportParticleAndVectors(meshPosition &pos, vecto
             double displacementLength = vectorMagnitude(displacementVector);
             displacementVector = newHeading*displacementLength;
             targetNormal = PMP::compute_face_normal(provisionalTargetFace,surface);
-	    target = edgeIntersectionPoint+displacementVector; 
-         
-	    //we don't need any of these if there are no vectors to transport
-	    if (transportVectors.size() > 0)
+            target = edgeIntersectionPoint+displacementVector; 
+
+            //we don't need any of these if there are no vectors to transport
+            if (transportVectors.size() > 0)
                 {  
-	        vector3 axisVector = normalize(CGAL::cross_product(currentSourceNormal,targetNormal)); 
+                vector3 axisVector = normalize(CGAL::cross_product(currentSourceNormal,targetNormal)); 
                 vector<point3> axis = {sourcePoint, sourcePoint+axisVector}; 
-	        double normalDotProduct = currentSourceNormal*targetNormal;
-	        double angle = acos(normalDotProduct);
-	        if (normalDotProduct >= 1) angle = 0; 
-            
-	        for (int i = 0; i < transportVectors.size(); i++)
+                double normalDotProduct = currentSourceNormal*targetNormal;
+                double angle = acos(normalDotProduct);
+                if (normalDotProduct >= 1) angle = 0; 
+
+                for (int i = 0; i < transportVectors.size(); i++)
                     {
                     vector3 vTr = transportVectors[i];
                     point3 vTrTarget = sourcePoint + vTr;
                     vTrTarget = rotateAboutAxis(vTrTarget, axis, angle);
                     transportVectors[i] = vector3(sourcePoint, vTrTarget);
                     }
-		}	   
+                }	   
 
-	    lastUsedHalfedge = nullHalfedge; 
-	    }
+            lastUsedHalfedge = nullHalfedge; 
+            }
 
         //update source face index info and new bary coords in  the new face.
         currentSourceFace = provisionalTargetFace;
         getVertexPositionsFromFace(surface,currentSourceFace, vertexPositions);
         //source face has changed, so we need to update the barycentric coords of source pt
-	sourceBarycentricLocation = PMP::barycentric_coordinates(vertexPositions[0], vertexPositions[1], vertexPositions[2], sourcePoint);  	
+        sourceBarycentricLocation = PMP::barycentric_coordinates(vertexPositions[0], vertexPositions[1], vertexPositions[2], sourcePoint);  	
 
-	currentSourceNormal = targetNormal;
-         
-	
+        currentSourceNormal = targetNormal;
+
         if(iter == maximumShiftEdgeCrossings)
             ERRORERROR("Error: shifted across too many faces. An inadvertently large displacement was almost certainly used.");
-        };
+
+        };//end of "while continue shifting" loop
 
     pos.faceIndex = currentSourceFace;
     pos.x = point3(targetBarycentricLocation[0],targetBarycentricLocation[1],targetBarycentricLocation[2]);   

--- a/src/models/triangulatedMeshSpace.cpp
+++ b/src/models/triangulatedMeshSpace.cpp
@@ -411,30 +411,6 @@ void triangulatedMeshSpace::projectVectorsIfOverBoundary(vector<vector3> &vector
         }
     }
 
-void triangulatedMeshSpace::clampAndUpdatePosition(pmpBarycentricCoordinates &baryLoc, point3 &r3Loc, faceIndex &sFace, bool belowZero)
-    {
-    if (belowZero) belowZeroClamp(baryLoc);
-    else nearZeroClamp(baryLoc);
-    //redefinitions ncessary after above clamp
-    meshPosition updatedMeshPos;
-    updatedMeshPos.x = point3(baryLoc[0], baryLoc[1], baryLoc[2]);
-    updatedMeshPos.faceIndex = sFace;
-    pmpFaceLocation updatedMeshLocation = meshPositionToFaceLocation(updatedMeshPos);
-    r3Loc = PMP::construct_point(updatedMeshLocation, surface);
-    }
-
-void triangulatedMeshSpace::checkBaryNan(pmpBarycentricCoordinates bcoords, string message, int step)
-    {
-    if(bcoords[0] != bcoords[0])
-         {
-         cout << endl;
-	 cout << "SHIFT HAS FAILED, TARGET BARY" << endl;
-	 cout << "message: " << message << endl;
-	 cout << "step: " << step << endl;
-	 cout << bcoords[0] << ", " << bcoords[1] << ", " << bcoords[2] << endl;
-	 ERRORERROR("Illegal coordinates");
-         }
-    }
 
 void triangulatedMeshSpace::displaceParticle(meshPosition &pos, vector3 &displacementVector)
     {

--- a/src/models/triangulatedMeshSpace.h
+++ b/src/models/triangulatedMeshSpace.h
@@ -15,6 +15,9 @@
 //! A class that interfaces with CGAL functionality for working with triangulated meshes
 /*!
 Note that this class interfaces tightly with some of the function in the meshUtilities files
+Currently, the code always considers boundary conditions -- for closed surfaces, they just aren't called. If useTangentialBCs is on, 
+transportParticleAndVectors will slide particles along the boundary rather than stop them. Future versions of the code will differentiate
+routines that use boundary conditions at all with routines that don't (for solely closed surfaces) in a modular way. 
 */
 class triangulatedMeshSpace : public baseSpace
     {
@@ -62,7 +65,7 @@ class triangulatedMeshSpace : public baseSpace
         //!given a vector of meshPositions that represent barycentric coordinates, fill a second vector of meshPositions that represent the corresponding R3 positions
         void convertToEuclideanPositions(std::vector<meshPosition> &a, std::vector<meshPosition> &b);
 
-	//!given a goal edge length, remesh the surface isotropically to have that edge length on average and set the new surface
+        //!given a goal edge length, remesh the surface isotropically to have that edge length on average and set the new surface
         void isotropicallyRemeshSurface(double targetEdgeLength);
 
         virtual void meshPositionToEuclideanLocation(std::vector<meshPosition> &p1, std::vector<double3> &result);
@@ -75,10 +78,9 @@ class triangulatedMeshSpace : public baseSpace
         double3 minVertexPosition;
         //!The upper-top-right position of the rectilinear domain containing the surface
         double3 maxVertexPosition;
-  	//!Currently, the code always considers boundary conditions -- for closed surfaces, they just aren't called. If useTangentialBCs is on, 
-	//transportParticleAndVectors will slide particles along the boundary rather than stop them. Future versions of the code will differentiate
-	//routines that use boundary conditions at all with routines that don't (for solely closed surfaces) in a modular way. 
-	bool useTangentialBCs = false;
+
+        //!A flag that sets boundary conditions. child classes may implement more sophisticated BCs
+        bool useTangentialBCs = false;
 
     protected:
         //!Update some internal datastructures used in finding shortest paths

--- a/src/models/triangulatedMeshSpace.h
+++ b/src/models/triangulatedMeshSpace.h
@@ -40,7 +40,7 @@ class triangulatedMeshSpace : public baseSpace
         virtual void randomVectorAtPosition(meshPosition &p, vector3 &v, noiseSource &noise);
 
         //!Get the area of the mesh
-        virtual double getArea();        
+        virtual double getArea();
 
         //!specialize the calculation of distances to use submeshes
         void distanceWithSubmeshing(meshPosition &p1, std::vector<meshPosition> &p2, std::vector<double> &distances, std::vector<vector3> &startPathTangent, std::vector<vector3> &endPathTangent,double distanceThreshold);
@@ -89,13 +89,9 @@ class triangulatedMeshSpace : public baseSpace
         shared_ptr<surfaceMeshShortestPath> globalSMSP;
         AABB_tree globalTree;
         bool submeshingActivated = false;
-	//!specialized function to assist with boundary conditions -- this is an outcome subfunction for boundary behaviors
+        //!specialized function to assist with boundary conditions -- this is an outcome subfunction for boundary behaviors
         virtual void projectVectorsIfOverBoundary(vector<vector3> &vectors, vector3 orthogonal, vector3 inward);
-	//!specalized functions for spot checks within the shift routine as well as simple wrappers around controlled clamps
-        void checkBaryNan(pmpBarycentricCoordinates bcoords, string message = "", int step = 0);
-        void clampAndUpdatePosition(pmpBarycentricCoordinates &baryLoc, point3 &r3Loc, faceIndex &sFace, bool belowZero = false);
-	
-	//!A data structure for helping with submeshing routines
+        //!A data structure for helping with submeshing routines
         submesher submeshAssistant;
         double maximumDistance = 0;
         //data structures associated with the potential for "dangerous" submeshes -- these can occur when submeshing routine is capable of returning a submesh with multiple connected components (e.g., when dealing with a surface that looks like an elephant's ear)

--- a/src/models/triangulatedMeshSpace.h
+++ b/src/models/triangulatedMeshSpace.h
@@ -24,8 +24,11 @@ class triangulatedMeshSpace : public baseSpace
         //!load data from an off file and initialize all mesh data structures
         void loadMeshFromFile(std::string filename, bool verbose = false);
 
+        //!displace particle just calls the transportParticleAndVectors function
+        virtual void displaceParticle(meshPosition &pos, vector3 &displacementVector);
+        
         //!Given a particle somewhere on the mesh, displace it in the direction of the vector, wrapping around faces; any vectors given to the function are transported along with it
-	virtual void transportParticleAndVectors(meshPosition &pos, vector3 &displacementVector, vector<vector3> &transportVectors);
+        virtual void transportParticleAndVectors(meshPosition &pos, vector3 &displacementVector, vector<vector3> &transportVectors);
 
         //!Given a source particle and a vector of target points, determine the geodesic distance and store the start and end path tangents along the paths
         virtual void distance(meshPosition &p1, std::vector<meshPosition> &p2, std::vector<double> &distances, std::vector<vector3> &startPathTangent, std::vector<vector3> &endPathTangent, double distanceThreshold= VERYLARGEDOUBLE);

--- a/src/updaters/fireMinimization.h
+++ b/src/updaters/fireMinimization.h
@@ -26,6 +26,14 @@ class fireMinimization : public velocityVerletNVE
         //!set all of the fire parameters
         void setFIREParameters(int _maximumIterations,double _deltaT, double _alphaStart, double _deltaTMax, double _deltaTMin, double _deltaTInc, double _deltaTDec, double _alphaDec, int _nMin, double _forceCutoff, double _alphaMin = 0.75);
 
+	virtual void setModel(shared_ptr<simpleModel> _model)
+            {
+            model=_model;
+            model->particleShiftsRequireVelocityTransport = true;
+            model->particleShiftsRequireForceTransport = true;
+	    initializeFromModel();
+            };
+
         double forceMax;
         double power;
         double forceNorm;

--- a/src/updaters/fireMinimization.h
+++ b/src/updaters/fireMinimization.h
@@ -26,12 +26,12 @@ class fireMinimization : public velocityVerletNVE
         //!set all of the fire parameters
         void setFIREParameters(int _maximumIterations,double _deltaT, double _alphaStart, double _deltaTMax, double _deltaTMin, double _deltaTInc, double _deltaTDec, double _alphaDec, int _nMin, double _forceCutoff, double _alphaMin = 0.75);
 
-	virtual void setModel(shared_ptr<simpleModel> _model)
+        virtual void setModel(shared_ptr<simpleModel> _model)
             {
             model=_model;
             model->particleShiftsRequireVelocityTransport = true;
             model->particleShiftsRequireForceTransport = true;
-	    initializeFromModel();
+            initializeFromModel();
             };
 
         double forceMax;

--- a/src/updaters/noseHooverNVT.h
+++ b/src/updaters/noseHooverNVT.h
@@ -29,8 +29,8 @@ class noseHooverNVT : public updater
             setBathVariables();
             };
 
-    //!compute the instantaneous kinetic temperature
-	double getTemperatureFromKE();
+        //!compute the instantaneous kinetic temperature
+        double getTemperatureFromKE();
 
     protected:
         vector<vector3> displacements;

--- a/src/utility/meshUtilities.cpp
+++ b/src/utility/meshUtilities.cpp
@@ -109,24 +109,49 @@ double totalArea(triangleMesh mesh)
     return area;
     };
 
-
-/*simple clamp function to take barycentric coordinate near the boundary of a face
- *and place it firmly within the face in question. Be careful this is not used when 
- *the barycentric coordinates are/might be very negative, as it can obscure meaningful errors. 
- */
-void clampToThreshold(pmpBarycentricCoordinates &baryPoint)
+void projectOn(vector3 &v, vector3 &direction) 
     {
+    //should only work if force is rotated along with all the other vectors
+    vector3 dhat = normalize(direction);
+    v = (v*dhat)*dhat;
+    }
+
+void projectOrthogonalTo(vector3 &v, vector3 &direction)
+    {
+    vector3 dhat = normalize(direction); 
+    v = v - (v*dhat)*dhat;
+    }
+
+void belowZeroClamp(pmpBarycentricCoordinates &baryPoint, double tol)
+    {
+    double clampedBarySum = 0;
     for (int i = 0; i < 3; i++)
         {
-        baryPoint[i] = max(baryPoint[i],THRESHOLD);
+        baryPoint[i] = max(baryPoint[i], tol);
+	clampedBarySum += baryPoint[i]; 
         }
-    double clampedBarySum = baryPoint[0]+baryPoint[1]+baryPoint[2];
     for (int i = 0; i < 3; i++)
         {
         baryPoint[i] = baryPoint[i]/clampedBarySum;
         }
     }
 
+void nearZeroClamp(pmpBarycentricCoordinates &baryPoint, double tol) 
+    {
+    double clampedBarySum = 0;
+    for (int i = 0; i < 3; i++)
+        {
+        if (baryPoint[i] > -tol && baryPoint[i] < tol) 
+	    {
+	    baryPoint[i] = tol;
+	    }
+	clampedBarySum += baryPoint[i]; 
+        }
+    for (int i = 0; i < 3; i++)
+        {
+        baryPoint[i] = baryPoint[i]/clampedBarySum;
+        }
+    } 
 
 /*
 Let a line in barycentric coordinates be 
@@ -290,12 +315,14 @@ void computePathDistanceAndTangents(surfaceMeshShortestPath *smsp, smspFaceLocat
     endPathTangent /= normalization;
     }
 
-
-void printPoint(point3 a)
+void printPoint(point3 a, bool precise)
     {
-    printf("{%f,%f,%f}",a[0],a[1],a[2]);
+    if (precise) printf("{%.16g,%.16g,%.16g}",a[0],a[1],a[2]);
+    else printf("{%f,%f,%f}",a[0],a[1],a[2]);
     };
-void printBary(smspBarycentricCoordinates a)
+
+void printBary(smspBarycentricCoordinates a, bool precise)
     {
-    printf("{%f,%f,%f}",a[0],a[1],a[2]);
+    if (precise) printf("{%.32g,%.32g,%.32g}",a[0],a[1],a[2]);
+    else printf("{%f,%f,%f}",a[0],a[1],a[2]);
     };

--- a/src/utility/meshUtilities.cpp
+++ b/src/utility/meshUtilities.cpp
@@ -160,6 +160,33 @@ void nearZeroClamp(pmpBarycentricCoordinates &baryPoint, double tol)
         baryPoint[i] = baryPoint[i]/clampedBarySum;
     } 
 
+void clampAndUpdatePosition(pmpBarycentricCoordinates &baryLoc, point3 &r3Loc, faceIndex &sFace, bool belowZero)
+    {
+    if (belowZero) 
+        belowZeroClamp(baryLoc);
+    else 
+        nearZeroClamp(baryLoc);
+    //update the original point for self-consistency
+    meshPosition updatedMeshPos;
+    updatedMeshPos.x = point3(baryLoc[0], baryLoc[1], baryLoc[2]);
+    updatedMeshPos.faceIndex = sFace;
+    pmpFaceLocation updatedMeshLocation = meshPositionToFaceLocation(updatedMeshPos);
+    r3Loc = PMP::construct_point(updatedMeshLocation, surface);
+    }
+
+void checkBaryNan(pmpBarycentricCoordinates bcoords, string message, int step)
+    {
+    if(bcoords[0] != bcoords[0])
+        {
+        cout << endl;
+        cout << "SHIFT HAS FAILED, TARGET BARY" << endl;
+        cout << "message: " << message << endl;
+        cout << "step: " << step << endl;
+        cout << bcoords[0] << ", " << bcoords[1] << ", " << bcoords[2] << endl;
+        ERRORERROR("Illegal coordinates");
+        }
+    }
+
 /*
 Let a line in barycentric coordinates be 
 l(t,start,end) = start + t(end-start),

--- a/src/utility/meshUtilities.cpp
+++ b/src/utility/meshUtilities.cpp
@@ -109,26 +109,32 @@ double totalArea(triangleMesh mesh)
     return area;
     };
 
-void projectOn(vector3 &v, vector3 &direction) 
+void projectVectorOntoDirection(vector3 &v, vector3 &direction) 
     {
-    //should only work if force is rotated along with all the other vectors
     vector3 dhat = normalize(direction);
     v = (v*dhat)*dhat;
     }
 
-void projectOrthogonalTo(vector3 &v, vector3 &direction)
+void projectVectorOrthongonalToDirection(vector3 &v, vector3 &direction)
     {
     vector3 dhat = normalize(direction); 
     v = v - (v*dhat)*dhat;
     }
 
+/*!
+Clamp a barycentric coordinate below zero to within the tolerance value, and then make sure the barycentric coordinates sum to one. 
+By default, belowZero clamp uses a stricter tolerance because it 
+acts on source points within shift -- source points error out in testing when allowed to be within 1e-12
+of a boundary, so belowZeroClamp guarantees a source point is never within that range or over the boundary.
+Because it acts on any bary coord < 0, it is used very sparingly -- essentially only for source points. 
+ */
 void belowZeroClamp(pmpBarycentricCoordinates &baryPoint, double tol)
     {
     double clampedBarySum = 0;
     for (int i = 0; i < 3; i++)
         {
         baryPoint[i] = max(baryPoint[i], tol);
-	clampedBarySum += baryPoint[i]; 
+        clampedBarySum += baryPoint[i]; 
         }
     for (int i = 0; i < 3; i++)
         {
@@ -136,21 +142,22 @@ void belowZeroClamp(pmpBarycentricCoordinates &baryPoint, double tol)
         }
     }
 
+/*!
+Clamp a barycentric coordinate near zero to the tolerance value, and then make sure the barycentric coordinates sum to one. 
+By default, The near zero clamp is less broadly acting, and keeps bary coords from being within 1e-13 of a boundary 
+because within that distance (either positive or negative), the intersection routine is liable to make errors. 
+ */
 void nearZeroClamp(pmpBarycentricCoordinates &baryPoint, double tol) 
     {
     double clampedBarySum = 0;
     for (int i = 0; i < 3; i++)
         {
         if (baryPoint[i] > -tol && baryPoint[i] < tol) 
-	    {
-	    baryPoint[i] = tol;
-	    }
-	clampedBarySum += baryPoint[i]; 
+            baryPoint[i] = tol;
+        clampedBarySum += baryPoint[i]; 
         }
     for (int i = 0; i < 3; i++)
-        {
         baryPoint[i] = baryPoint[i]/clampedBarySum;
-        }
     } 
 
 /*

--- a/src/utility/meshUtilities.cpp
+++ b/src/utility/meshUtilities.cpp
@@ -160,7 +160,7 @@ void nearZeroClamp(pmpBarycentricCoordinates &baryPoint, double tol)
         baryPoint[i] = baryPoint[i]/clampedBarySum;
     } 
 
-void clampAndUpdatePosition(pmpBarycentricCoordinates &baryLoc, point3 &r3Loc, faceIndex &sFace, bool belowZero)
+void clampAndUpdatePosition(pmpBarycentricCoordinates &baryLoc, point3 &r3Loc, faceIndex &sFace, triangleMesh &surface, bool belowZero)
     {
     if (belowZero) 
         belowZeroClamp(baryLoc);

--- a/src/utility/meshUtilities.h
+++ b/src/utility/meshUtilities.h
@@ -68,8 +68,19 @@ double meanTriangleArea(triangleMesh mesh);
 //! Return the total surface area of a mesh
 double totalArea(triangleMesh mesh); 
 
-//! avoid finite-numerical-precision artifacts by clamping points near an edge to have a zero barycentric coordinate
-void clampToThreshold(pmpBarycentricCoordinates &baryPoint);
+//!Functions to perform simple projections 'on' (align with) or 'off' (make perpendicular to) a given vector
+void projectOn(vector3 &v, vector3 &direction);
+void projectOrthogonalTo(vector3 &v, vector3 &direction);
+
+//!Special clamps for shift functions. belowZero clamp uses a stricter tolerance because it 
+//acts on source points within shift -- source points error out in testing when allowed to be within 1e-12
+//of a boundary, so belowZeroClamp guarantees a source point is never within that range or over the boundary.
+//Because it acts on any bary coord < 0, it is used very sparingly -- essentially only for source points. 
+//The near zero clamp is less broadly acting, and keeps bary coords from being within 1e-13 of a boundary 
+//because within that distance (either positive or negative), the intersection routine is liable to make errors. 
+void belowZeroClamp(pmpBarycentricCoordinates &baryPoint, double tol = 1e-11);
+void nearZeroClamp(pmpBarycentricCoordinates &baryPoint, double tol = 1e-13);
+
 
 //!return true if the two lines which pass through the given endpoints intersect between the specified points on both lines. fill in the barycentric location of the intersection point
 bool intersectionOfLinesInBarycentricCoordinates(pmpBarycentricCoordinates line1Start, pmpBarycentricCoordinates line1End, pmpBarycentricCoordinates line2Start, pmpBarycentricCoordinates line2End, pmpBarycentricCoordinates &intersectionPoint);
@@ -91,9 +102,10 @@ void convertBarycentricCoordinates(triangleMesh &mesh1, triangleMesh &mesh2, std
 //! Given the right data structures, compute the geodesic path and start/end tangent vectors between points
 void computePathDistanceAndTangents(surfaceMeshShortestPath *smsp, smspFaceLocation &targetPoint, double &distance, vector3 &startPathTangent, vector3 &endPathTangent);
 
-//!Print to screen the coordinates of a point.
-void printPoint(point3 a);
-//! print to screen a set of barycentric coordinates
-void printBary(smspBarycentricCoordinates a);
+//!Print to screen the coordinates of a point, with full precision allowed using precise=true
+void printPoint(point3 a, bool precise=false);
+
+//! print to screen a set of barycentric coordinates, with full precision allowed using precise=true
+void printBary(smspBarycentricCoordinates a, bool precise=false);
 
 #endif

--- a/src/utility/meshUtilities.h
+++ b/src/utility/meshUtilities.h
@@ -105,4 +105,9 @@ void printPoint(point3 a, bool precise=false);
 //! print to screen a set of barycentric coordinates, with full precision allowed using precise=true
 void printBary(smspBarycentricCoordinates a, bool precise=false);
 
+//! specialized function to test for NaN in barycentric coordinates, with debugging output
+void checkBaryNan(pmpBarycentricCoordinates bcoords, string message = "", int step = 0);
+//! As simple wrappers around controlled clamps
+void clampAndUpdatePosition(pmpBarycentricCoordinates &baryLoc, point3 &r3Loc, faceIndex &sFace, bool belowZero = false);
+	
 #endif

--- a/src/utility/meshUtilities.h
+++ b/src/utility/meshUtilities.h
@@ -106,8 +106,8 @@ void printPoint(point3 a, bool precise=false);
 void printBary(smspBarycentricCoordinates a, bool precise=false);
 
 //! specialized function to test for NaN in barycentric coordinates, with debugging output
-void checkBaryNan(pmpBarycentricCoordinates bcoords, string message = "", int step = 0);
+void checkBaryNan(pmpBarycentricCoordinates bcoords, std::string message = "", int step = 0);
 //! As simple wrappers around controlled clamps
-void clampAndUpdatePosition(pmpBarycentricCoordinates &baryLoc, point3 &r3Loc, faceIndex &sFace, bool belowZero = false);
+void clampAndUpdatePosition(pmpBarycentricCoordinates &baryLoc, point3 &r3Loc, faceIndex &sFace, triangleMesh &surface, bool belowZero = false);
 	
 #endif

--- a/src/utility/meshUtilities.h
+++ b/src/utility/meshUtilities.h
@@ -68,17 +68,14 @@ double meanTriangleArea(triangleMesh mesh);
 //! Return the total surface area of a mesh
 double totalArea(triangleMesh mesh); 
 
-//!Functions to perform simple projections 'on' (align with) or 'off' (make perpendicular to) a given vector
-void projectOn(vector3 &v, vector3 &direction);
-void projectOrthogonalTo(vector3 &v, vector3 &direction);
+//! Transform v by removing any component orthogonal to the direction
+void projectVectorOntoDirection(vector3 &v, vector3 &direction);
+//! Transform v by removing any component parallel to the direction
+void projectVectorOrthongonalToDirection(vector3 &v, vector3 &direction);
 
-//!Special clamps for shift functions. belowZero clamp uses a stricter tolerance because it 
-//acts on source points within shift -- source points error out in testing when allowed to be within 1e-12
-//of a boundary, so belowZeroClamp guarantees a source point is never within that range or over the boundary.
-//Because it acts on any bary coord < 0, it is used very sparingly -- essentially only for source points. 
-//The near zero clamp is less broadly acting, and keeps bary coords from being within 1e-13 of a boundary 
-//because within that distance (either positive or negative), the intersection routine is liable to make errors. 
+//!clamp negative barycentric points to within the tolerance
 void belowZeroClamp(pmpBarycentricCoordinates &baryPoint, double tol = 1e-11);
+//!clamp barycentric points near zero to the tolerance
 void nearZeroClamp(pmpBarycentricCoordinates &baryPoint, double tol = 1e-13);
 
 


### PR DESCRIPTION
Hi Daniel! I've gone through and made all of the functional changes from the paper_branch that allow shift to handle basic boundary conditions & compress shift into just one function with triangulatedMeshSpace, along with force transport. Checking against the very basic main routine ( ./curvedSpaceSimulation.out -z 1) the result is (for now) identical. 